### PR TITLE
For subcommands using IPC, put the client in cmd/

### DIFF
--- a/cmd/agent/health/command.go
+++ b/cmd/agent/health/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/djmitche/dd-agent-comp-experiments/cmd/agent/root"
 	"github.com/djmitche/dd-agent-comp-experiments/cmd/common"
 	"github.com/djmitche/dd-agent-comp-experiments/comp/core/health"
+	"github.com/djmitche/dd-agent-comp-experiments/comp/core/ipc/ipcclient"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 )
@@ -32,8 +33,18 @@ func command(_ *cobra.Command, args []string) error {
 	return common.RunApp(app)
 }
 
-func healthCmd(health health.Component) error {
-	resp, err := health.GetHealthRemote()
+func getHealthRemote(ipcclient ipcclient.Component) (map[string]health.ComponentHealth, error) {
+	var content map[string]health.ComponentHealth
+	err := ipcclient.GetJSON("/agent/health", &content)
+	if err != nil {
+		return nil, err
+	}
+
+	return content, nil
+}
+
+func healthCmd(ipcclient ipcclient.Component, health health.Component) error {
+	resp, err := getHealthRemote(ipcclient)
 	if err != nil {
 		return err
 	}

--- a/comp/core/flare/component.go
+++ b/comp/core/flare/component.go
@@ -37,10 +37,6 @@ type Component interface {
 	// CreateFlare creates a new flare locally and returns the path to the
 	// flare file.
 	CreateFlare() (string, error)
-
-	// CreateFlareRemote calls the running Agent's IPC API to instruct it to
-	// generate a flare remotely.
-	CreateFlareRemote() (string, error)
 }
 
 // Mock implements mock-specific methods.

--- a/comp/core/health/component.go
+++ b/comp/core/health/component.go
@@ -34,9 +34,6 @@ type Component interface {
 	// GetHealth gets a map containing the health of all components.  This map is a copy
 	// and will not be altered after return.
 	GetHealth() map[string]ComponentHealth
-
-	// GetHealthRemote gets the same value as GetHealth, but using the IPC API.
-	GetHealthRemote() (map[string]ComponentHealth, error)
 }
 
 // Registration is provided by other components in order to register those

--- a/comp/core/status/component.go
+++ b/comp/core/status/component.go
@@ -25,9 +25,6 @@ type Component interface {
 	// GetStatus gets the agent status.  If the section parameter is not empty, then
 	// only that section's status is returned.  This is a newline-terminated string.
 	GetStatus(section string) string
-
-	// GetStatus gets the same value as GetStatus, but using the IPC API.
-	GetStatusRemote(section string) (string, error)
 }
 
 // Registration is provided by other components in order to register sections

--- a/doc/conventions.md
+++ b/doc/conventions.md
@@ -180,12 +180,9 @@ Note that l.subscription is nil if the component does not start, meaning that th
 ## IPC API Commands
 
 Several commands, such as `agent status` or `agent config`, call the running Agent's IPC API and format the result.
-Components implementing this pattern should generally have two similar methods, such as `GetStatus` and `GetStatusRemote`.
-The first method gathers the data locally, and the second requests the same data via the IPC API.
-The component should plugin to `comp/core/ipc/ipcserver` to provide the result of the first method over the IPC API.
+Components implementing this pattern generally have a method to get the data, such as `GetStatus`, and also publish this information over the IPC API.
 
-This arrangement locates both the client and server sides of the IPC API in one module.
-The command implementation (under `cmd/`) then simply calls `GetStatusRemote` and formats the result for display.
+The subcommand (e.g., `agent status`) implements the client side of this transaction, using `comp/core/ipc/ippclient` to fetch, format, and display the data.
 
 ## Health Monitoring
 


### PR DESCRIPTION
This splits the client and server sides of these APIs, but they're APIs
we're comfortable with other clients accessing as well, so not something
we change frequently.  The `comp/core/ipc/ipcclient` component makes it
easy enough to fetch the data that this is not a great hardship or
introducing a great deal of logic into the command.

Fixes #11.