### PR TITLE
refuse to load on-disk config if in a test binary

### DIFF
--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/dd-agent-comp-experiments/comp/core/internal"
+	"github.com/DataDog/dd-agent-comp-experiments/pkg/util/testing"
 	"github.com/spf13/viper"
 	"go.uber.org/fx"
 )
@@ -26,6 +27,9 @@ type dependencies struct {
 
 func newConfig(deps dependencies) (Component, error) {
 	v := viper.New()
+	if testing.InTestBinary {
+		panic("do not use non-mock comp/core/config in tests")
+	}
 	v.SetConfigName("datadog")
 	v.SetEnvPrefix("DD_")
 	v.SetConfigType("yaml")

--- a/pkg/util/testing/istest.go
+++ b/pkg/util/testing/istest.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package testing
+
+import (
+	"os"
+	"strings"
+)
+
+// InTestBinary is true if the running binary is a Go test.
+var InTestBinary bool
+
+func init() {
+	// 'go test' generates binaries with a `.test` suffix and runs
+	// them, so we can detect that this is a test binary by looking
+	// at the filename.
+	InTestBinary = strings.HasSuffix(os.Args[0], ".test")
+}


### PR DESCRIPTION
This fixes #20.  Basically it means that a dev (like me) can't accidentally write tests that depend on their local `/etc/datadog-agent` or `$DD_` settings.